### PR TITLE
remove type attribute and fix spelling typos 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This repository is a part of the [ChatEngine Framework](https://github.com/pubnub/chat-engine).
 For more information on building chat applications with PubNub, see our
-[Chat Resource Center](http://www.pubnub.com/developers/chat-resource-center/).
+[Chat Resource Center](https://www.pubnub.com/developers/chat-resource-center/).
 
 # PubNub ChatEngine Examples
 

--- a/angular/flowtron/electron/README.md
+++ b/angular/flowtron/electron/README.md
@@ -6,7 +6,7 @@ npm install
 
 ## To Run:
 
-First open the ```app.js``` file located ```../chat-engine-examples/angular/flowtron/app.js``` and replace the empty string value for both the ```userPubKey``` and ```userSubKey``` (app.js:50-51).
+First, open the ```app.js``` file located ```../chat-engine-examples/angular/flowtron/app.js``` and replace the empty string value for both the ```userPubKey``` and ```userSubKey``` (app.js:50-51).
 
 ```js
 // REPLACE EMPTY STRING WITH ChatEngine PUB/SUB keys

--- a/angular/flowtron/index.html
+++ b/angular/flowtron/index.html
@@ -2,7 +2,7 @@
 <html ng-app="chatApp">
 
 <head>
-    <script type="text/javascript">
+    <script>
     if (typeof module === 'object') {
 
         window.ipcRenderer = require('electron').ipcRenderer
@@ -17,16 +17,16 @@
     </script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
     <link rel="stylesheet" href="./styles.css">
-    <script src="bower_components/angular/angular.js" type="text/javascript"></script>
-    <script src="bower_components/angular-sanitize/angular-sanitize.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-unread-messages/dist/chat-engine-unread-messages.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-desktop-notifications/dist/chat-engine-desktop-notifications.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-emoji/dist/chat-engine-emoji.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-markdown/dist/chat-engine-markdown.js" type="text/javascript"></script>
+    <script src="bower_components/angular/angular.js"></script>
+    <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
+    <script src="../../node_modules/chat-engine/dist/chat-engine.js"></script>
+    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js"></script>
+    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js"></script>
+    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js"></script>
+    <script src="../../node_modules/chat-engine-unread-messages/dist/chat-engine-unread-messages.js"></script>
+    <script src="../../node_modules/chat-engine-desktop-notifications/dist/chat-engine-desktop-notifications.js"></script>
+    <script src="../../node_modules/chat-engine-emoji/dist/chat-engine-emoji.js"></script>
+    <script src="../../node_modules/chat-engine-markdown/dist/chat-engine-markdown.js"></script>
     <script>
     UPLOADCARE_LOCALE = "en";
     UPLOADCARE_TABS = "file url facebook gdrive dropbox instagram evernote flickr skydrive";

--- a/angular/simple/index.html
+++ b/angular/simple/index.html
@@ -4,7 +4,7 @@
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
 
-    <style type="text/css">
+    <style>
     body {margin-top: 10px;}
     .log {
         padding: 10px;
@@ -26,10 +26,10 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular.min.js"></script>
 
-    <script src="../../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js" type="text/javascript"></script>
+    <script src="../../node_modules/chat-engine/dist/chat-engine.js"></script>
+    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js"></script>
+    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js"></script>
+    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js"></script>
 
     <script src="plugin.js"></script>
     <script src="app.js"></script>

--- a/javascript/chat.html
+++ b/javascript/chat.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>PubNub ChatEngine</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
-    <style type="text/css">
+    <style>
     * {
         margin: 0px;
         padding: 0px;
@@ -33,8 +33,8 @@
                 </div>
             </div>
         </div>
-        <script src="../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-        <script src="chat.js" type="text/javascript"></script>
+        <script src="../node_modules/chat-engine/dist/chat-engine.js"></script>
+        <script src="chat.js"></script>
 </body>
 
 </html>

--- a/javascript/desktop.html
+++ b/javascript/desktop.html
@@ -3,7 +3,7 @@
 
 <head>
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"></link>
-    <style type="text/css">
+    <style>
     * {
         margin: 0;
         padding: 0;
@@ -432,10 +432,10 @@
             </div>
         </li>
     </script>
-    <script src="../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-    <script src="../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js" type="text/javascript"></script>
-    <script src="../node_modules/chat-engine-markdown/dist/chat-engine-markdown.js" type="text/javascript"></script>
-    <script src="desktop.js" type="text/javascript"></script>
+    <script src="../node_modules/chat-engine/dist/chat-engine.js"></script>
+    <script src="../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js"></script>
+    <script src="../node_modules/chat-engine-markdown/dist/chat-engine-markdown.js"></script>
+    <script src="desktop.js"></script>
 </body>
 
 </html>

--- a/javascript/facebook-login.html
+++ b/javascript/facebook-login.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>PubNub ChatEngine</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
-    <style type="text/css">
+    <style>
     * {
         margin: 0px;
         padding: 0px;
@@ -18,9 +18,9 @@
 </head>
 
 <body>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-    <script src="../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-    <script type="text/javascript">
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="../node_modules/chat-engine/dist/chat-engine.js"></script>
+    <script>
     const ChatEngine = ChatEngineCore.create({
         publishKey: 'pub-c-d8599c43-cecf-42ba-a72f-aa3b24653c2b',
         subscribeKey: 'sub-c-6c6c021c-c4e2-11e7-9628-f616d8b03518'

--- a/javascript/js_example.md
+++ b/javascript/js_example.md
@@ -1,7 +1,7 @@
 # PubNub ChatEngine - Javascript Desktop Ex.
 
 ## Quick Setup
-Great news! You're moments away from running your very own ChatEngine client.. In case you missed it, please ensure you have setup ChatEngine via PubNub's (Quick Start)[https://www.pubnub.com/docs/tutorials/chatengine] guide. Doing so will allow you to use your own PubNub application keyset.
+Great news! You're moments away from running your very own ChatEngine client. In case you missed it, please ensure you have setup ChatEngine via PubNub's (Quick Start)[https://www.pubnub.com/docs/tutorials/chatengine] guide. Doing so will allow you to use your own PubNub application keyset.
 
 Ensure a static file server is running from the parent directory of the repo.
 If not, instantiate a static HTTP server from the project root (either NodeJS or Python):
@@ -27,7 +27,7 @@ Once the server is running, open the javascript/desktop.html file in your prefer
 
 To further experience the functionality of the Javascript ChatEngine example, open javascript/desktop.html in a local incognito browser to chat with yourself.
 
-It should be noted that upon refreshing the webpage, a new user will be created for you to impersonate. After refreshing the chat webpgae, please note that users previously created will linger for a small time before the client determines the previously created user instance is _offline_.
+It should be noted that upon refreshing the webpage, a new user will be created for you to impersonate. After refreshing the chat webpage, please note that users previously created will linger for a small time before the client determines the previously created user instance is _offline_.
 
 ## Personalization
 By now you should have one desktop client (or more) running locally. Time to inject your PubNub publish & subscribe keys into the application.
@@ -42,11 +42,11 @@ let userSubKey = '' || 'sub-c-6c6c021c-c4e2-11e7-9628-f616d8b03518';
 ```
 Be wary when instantiating ChatEngine with argument `debug`:`true`. Leaving the option `true` will output `console.debug()` statements to the browser running the client. With greater load, this flag will cause delays and slowness. Be sure to set debug: `false` or simply don't include the arg (defaults to `false`).
 
-Once finished, be sure to save the changes to javascript/desktop.js and refresh your browser. Once refreshed, the client application will utilize your personal PubNub keys to power ChatEngine. By removing the demo keys, you've setup a chat application which remains private to those who don't know your Publish & Subscribe keys.
+Once finished, be sure to save the changes to javascript/desktop.js and refresh your browser. Once refreshed, the client application will utilize your personal PubNub keys to power ChatEngine. By removing the demo keys, you've set up a chat application which remains private to those who don't know your Publish & Subscribe keys.
 
 
 ### User Presence
-Ideally a chat client would display whether or not users are online or offline. Thankfully PubNub's Presence feature provides such functionallity. Lets take a look at the `bindUsers()` function within javascript/desktop.js:
+Ideally, a chat client would display whether or not users are online or offline. Thankfully PubNub's Presence feature provides such functionality. Let's take a look at the `bindUsers()` function within javascript/desktop.js:
 
 ```javascript
 // add PubNub Presence: to display users [online|offline] state
@@ -75,7 +75,7 @@ bindUsers: function() {
 ```
 
 ### Chat History
-Currently the application does not render messages previously sent prior to invoking the current session. Thankfully CE allows one to easily populate the chat history with messages previously sent on a specified chat channel. To do so, uncomment the following snippet within below the `ready()` function within javacript/desktop.js:
+Currently, the application does not render messages previously sent prior to invoking the current session. Thankfully CE allows one to easily populate the chat history with messages previously sent on a specified chat channel. To do so, uncomment the following snippet within below the `ready()` function within javacript/desktop.js:
 
 ```javascript
 ready: function(data) {
@@ -107,7 +107,7 @@ ready: function(data) {
 CE provides many off the shelf plugins, in this example I'll provide you with the steps to add markdown rendering to your chat messages. Navigate to the `ready()` function and uncomment the following:
 
 ```Javascript
-// UNCOMMENT code below to enbale the 'markdown-plugin'
+// UNCOMMENT code below to enable the 'markdown-plugin'
 const markdown = ChatEngineCore.plugin['chat-engine-markdown']();
 this.chat.plugin(markdown);
 ```

--- a/javascript/online-list.html
+++ b/javascript/online-list.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>PubNub ChatEngine</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
-    <style type="text/css">
+    <style>
     * {
         margin: 0px;
         padding: 0px;
@@ -29,8 +29,8 @@
             </div>
         </div>
         <div id="chat-online"></div>
-        <script src="../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-        <script src="onlineList.js" type="text/javascript"></script>
+        <script src="../node_modules/chat-engine/dist/chat-engine.js"></script>
+        <script src="onlineList.js"></script>
 </body>
 
 </html>

--- a/jquery/kitchen-sink/index.html
+++ b/jquery/kitchen-sink/index.html
@@ -7,7 +7,7 @@
     <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
-    <style type="text/css">
+    <style>
     body {
         margin-top: 10px;
     }
@@ -63,11 +63,11 @@
             </div>
         </div>
     </div>
-    <script src="../../../chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js" type="text/javascript"></script>
-    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js" type="text/javascript"></script>
-    <script src="./app.js" type="text/javascript"></script>
+    <script src="../../../chat-engine/dist/chat-engine.js"></script>
+    <script src="../../node_modules/chat-engine-typing-indicator/dist/chat-engine-typing-indicator.js"></script>
+    <script src="../../node_modules/chat-engine-online-user-search/dist/chat-engine-online-user-search.js"></script>
+    <script src="../../node_modules/chat-engine-random-username/dist/chat-engine-random-username.js"></script>
+    <script src="./app.js"></script>
 </body>
 
 </html>

--- a/jquery/simple/index.html
+++ b/jquery/simple/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>PubNub ChatEngine</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
-    <style type="text/css">
+    <style>
     * {
         margin: 0px;
         padding: 0px;
@@ -34,9 +34,9 @@
                 </div>
             </div>
         </div>
-        <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-        <script src="../../node_modules/chat-engine/dist/chat-engine.js" type="text/javascript"></script>
-        <script type="text/javascript">
+        <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+        <script src="../../node_modules/chat-engine/dist/chat-engine.js"></script>
+        <script>
         const username = ['user', new Date().getTime()].join('-');
 
         const ChatEngine = ChatEngineCore.create({

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -138,7 +138,7 @@ To add a local dependency to the correct Flow version to a Create React Native A
 4. Add `// @flow` to any files you want to type check (for example, to `App.js`).
 
 Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.
-You can optionally use a [plugin for your IDE or editor](https://flow.org/en/docs/editors/) for a better integrated experience.
+You can optionally use a [plugin for your IDE or editor](https://flow.org/en/docs/editors/) for a better-integrated experience.
 
 To learn more about Flow, check out [its documentation](https://flow.org/).
 
@@ -175,7 +175,7 @@ If you have made use of Expo APIs while working on your project, then those API 
 
 ### Networking
 
-If you're unable to load your app on your phone due to a network timeout or a refused connection, a good first step is to verify that your phone and computer are on the same network and that they can reach each other. Create React Native App needs access to ports 19000 and 19001 so ensure that your network and firewall settings allow access from your device to your computer on both of these ports.
+If you're unable to load your app on your phone due to a network timeout or a refused connection, a good first step is to verify that your phone and computer are on the same network and that they can reach each other. Create React Native App needs access to ports 19000 and 19001 to ensure that your network and firewall settings allow access from your device to your computer on both of these ports.
 
 Try opening a web browser on your phone and opening the URL that the packager script prints, replacing `exp://` with `http://`. So, for example, if underneath the QR code in your terminal you see:
 


### PR DESCRIPTION
1. changing `http` to `https` to avoid redirect. (PubNub Website doesn't work on `http` and gets redirected to `https`)
1. fix spelling typos
1. remove `type` attribute (`type` attribute is not needed for the style element and is unnecessary for JavaScript resources.)